### PR TITLE
connect game manager script to game manager node

### DIFF
--- a/bachelors-workshop-game/root_scene.tscn
+++ b/bachelors-workshop-game/root_scene.tscn
@@ -1,7 +1,9 @@
-[gd_scene load_steps=2 format=3 uid="uid://hamba2momkwj"]
+[gd_scene load_steps=3 format=3 uid="uid://hamba2momkwj"]
 
 [ext_resource type="PackedScene" uid="uid://ubde8gsh24gy" path="res://scenes/main_menu.tscn" id="1_k687t"]
+[ext_resource type="Script" path="res://scripts/game_manager.gd" id="1_qr1ex"]
 
 [node name="GameManager" type="Node"]
+script = ExtResource("1_qr1ex")
 
 [node name="MainMenu" parent="." instance=ExtResource("1_k687t")]


### PR DESCRIPTION
a game manager with support for basic states such as: main menu, in game, paused, round end, cleanup, and game over. includes a subscribable signal (not sure if this is implemented yet) for these state changes. also includes citytime and a respective getter and resetter, as well as basic getters for our player characters and their properties (just supply count for now).